### PR TITLE
v0.4.4 use substrate-lib 3.0.1 for updated polkadot api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lorena-ssi/did-resolver",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Resolve DID Documents from DIDs in the Lorena namespace",
   "main": "index.js",
   "author": "Caelum Labs",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@lorena-ssi/matrix-lib": "^1.0.13",
     "@lorena-ssi/maxonrow-lib": "^1.2.3",
-    "@lorena-ssi/substrate-lib": "^3.0.0",
+    "@lorena-ssi/substrate-lib": "^3.0.1",
     "bip39": "^3.0.2"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-chai-friendly": "^0.6.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsdoc": "^25.2.1",
+    "eslint-plugin-jsdoc": "^25.4.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",


### PR DESCRIPTION
https://app.clubhouse.io/caelum-labs/story/991/update-all-libraries-with-latest-polkadot-api